### PR TITLE
cherry-picking commit 384b862.

### DIFF
--- a/test/unit/vdom/properties.js
+++ b/test/unit/vdom/properties.js
@@ -1,6 +1,6 @@
 import afterMutations from '../../lib/after-mutations';
 import fixture from '../../lib/fixture';
-import { define, prop, props, symbols, vdom } from '../../../src/index';
+import { Component, define, h, prop, props, vdom } from '../../../src/index';
 
 describe('vdom/properties', () => {
   it('class -> className', done => {
@@ -100,5 +100,24 @@ describe('vdom/properties', () => {
         done
       );
     });
+  });
+
+  it('#876 - Apply prop attributes as properties in a polyfill environment', (done) => {
+    const Elem1 = define('x-test', {
+      render (elem) {
+        return h(Elem2, { fooBar: true });
+      }
+    });
+    const Elem2 = define('x-test', {
+      props: {
+        fooBar: {}
+      },
+      render(elem) {
+        expect(elem.fooBar).to.be.equal(true);
+        done();
+      }
+    });
+    const elem = new Elem1();
+    fixture(elem);
   });
 });


### PR DESCRIPTION
fix: Fix issue causing polyfill-land to not get props if they're not updated yet.
Updated logic to always set props on anything that looks like a custom element.
fixes #876